### PR TITLE
Update scipy pin to match upstream

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 700a53187e462591ff45b9118ca84bde29e3be2c43e64bdf692e3d163acf0365
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -22,12 +22,13 @@ requirements:
   run:
     - python >=3.6
     - numba >=0.45
-    - scipy >=0.16,<1.6.2
+    - scipy >=0.16,<=1.7.3
     - setuptools
 
 test:
   requires:
     - pip
+    - numpy =1.22
   commands:
     - pip check
   imports:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Latest version of `numba-scipy` can work with `scipy` up-to `1.7.3`, so updating dependency in there. ~I had to add "fake dependency" on `numpy <1.23` for things to install properly. This is because `conda-forge` variants of `scipy=1.7.*` packages do not declare `numpy` constraint as it is defined in source distribution, so `pip check` due to `numpy` being too recent. Since `numpy` is a transitive dependency anyway I think this should be ok.~


UPDATE: older versions of `scipy` on `conda-forge` are fixed now, but broken packages might still be around, so I have added `numpy` pin for test environment construction, there is no direct `numpy` dependency on the output package itself.


<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
